### PR TITLE
Implement async updates for transcrever_audio tool

### DIFF
--- a/professor-virtual/professor_virtual/tools/transcrever_audio/transcrever_audio.py
+++ b/professor-virtual/professor_virtual/tools/transcrever_audio/transcrever_audio.py
@@ -61,7 +61,7 @@ def _limpar_cache_se_necessario():
             del _transcription_cache[key]
 
 
-def transcrever_audio(
+async def transcrever_audio(
     nome_artefato_audio: str, 
     tool_context: ToolContext
 ) -> Dict[str, Any]:
@@ -78,11 +78,11 @@ def transcrever_audio(
     """
     try:
         # Carregar artifact usando método correto da documentação
-        audio_artifact = tool_context.load_artifact(nome_artefato_audio)
+        audio_artifact = await tool_context.load_artifact(nome_artefato_audio)
         
         if not audio_artifact:
             # Tentar buscar na mensagem do usuário como fallback
-            audio_artifact = _buscar_audio_na_mensagem(tool_context)
+            audio_artifact = await _buscar_audio_na_mensagem(tool_context)
             if not audio_artifact:
                 return {
                     "sucesso": False,
@@ -196,7 +196,7 @@ Se houver múltiplos falantes, indique com "Falante 1:", "Falante 2:", etc."""
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
             transcript_artifact = types.Part.from_text(text=texto_transcrito)
             filename = f"transcricao_{timestamp}.txt"
-            versao_salva = tool_context.save_artifact(filename, transcript_artifact)
+            versao_salva = await tool_context.save_artifact(filename, transcript_artifact)
             arquivo_salvo = filename
         except Exception as e:
             logger.warning(f"Não foi possível salvar transcrição: {e}")
@@ -284,7 +284,7 @@ def _extrair_dados_do_artifact(artifact) -> tuple[bytes, str]:
     return None, None
 
 
-def _buscar_audio_na_mensagem(tool_context: ToolContext) -> Optional[Any]:
+async def _buscar_audio_na_mensagem(tool_context: ToolContext) -> Optional[Any]:
     """Busca áudio na mensagem do usuário como fallback.
     
     Baseado na documentação do ADK sobre acesso a user_content.

--- a/tasks.json
+++ b/tasks.json
@@ -73,13 +73,18 @@
       "id": 5,
       "title": "Update transcrever_audio.py to be async and fix deprecated APIs",
       "description": "Convert transcrever_audio function to async and fix deprecated artifact loading/saving APIs, including updating the auxiliary function _buscar_audio_na_mensagem",
-      "status": "pending",
+      "status": "done",
       "dependencies": [
         2
       ],
       "priority": "high",
       "details": "### PROBLEMA 1: Método deve ser assíncrono\n\n**❌ REMOVER (linha 46):**\n```python\ndef transcrever_audio(\n```\n\n**✅ SUBSTITUIR POR:**\n```python\nasync def transcrever_audio(\n```\n\n### PROBLEMA 2: load_artifact deve usar await\n\n**❌ REMOVER (linha 61):**\n```python\n        audio_artifact = tool_context.load_artifact(nome_artefato_audio)\n```\n\n**✅ SUBSTITUIR POR:**\n```python\n        audio_artifact = await tool_context.load_artifact(nome_artefato_audio)\n```\n\n### PROBLEMA 3: save_artifact deve usar await\n\n**❌ REMOVER (linha 151):**\n```python\n            versao_salva = tool_context.save_artifact(filename, transcript_artifact)\n```\n\n**✅ SUBSTITUIR POR:**\n```python\n            versao_salva = await tool_context.save_artifact(filename, transcript_artifact)\n```\n\n### PROBLEMA 4: Função auxiliar _buscar_audio_na_mensagem\n\n**❌ REMOVER (linha 227):**\n```python\ndef _buscar_audio_na_mensagem(tool_context: ToolContext) -> Optional[Any]:\n```\n\n**✅ SUBSTITUIR POR:**\n```python\nasync def _buscar_audio_na_mensagem(tool_context: ToolContext) -> Optional[Any]:\n```\n\n**❌ REMOVER (linha 65):**\n```python\n            audio_artifact = _buscar_audio_na_mensagem(tool_context)\n```\n\n**✅ SUBSTITUIR POR:**\n```python\n            audio_artifact = await _buscar_audio_na_mensagem(tool_context)\n```",
-      "testStrategy": "Verify that transcrever_audio function is async, uses await with tool_context.load_artifact() and tool_context.save_artifact(), the auxiliary function _buscar_audio_na_mensagem is also async, and all calls to _buscar_audio_na_mensagem use await"
+      "testStrategy": "Verify that transcrever_audio function is async, uses await with tool_context.load_artifact() and tool_context.save_artifact(), the auxiliary function _buscar_audio_na_mensagem is also async, and all calls to _buscar_audio_na_mensagem use await",
+      "started_at": "2025-07-30T18:28:19Z",
+      "completed_at": "2025-07-30T18:29:20Z",
+      "files_modified": [
+        "professor-virtual/professor_virtual/tools/transcrever_audio/transcrever_audio.py"
+      ]
     },
     {
       "id": 6,


### PR DESCRIPTION
## Summary
- make `transcrever_audio` asynchronous
- await artifact load/save operations
- update helper `_buscar_audio_na_mensagem` to be async
- adjust task tracking

## Testing
- `python3 -m py_compile professor-virtual/professor_virtual/tools/transcrever_audio/transcrever_audio.py`
- `PYTHONPATH=professor-virtual python3 - <<'PY'
import professor_virtual.tools.transcrever_audio.transcrever_audio as mod
print('loaded:', hasattr(mod, 'transcrever_audio'))
PY` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_688a6396ff4083218003aff4ab4dcf46